### PR TITLE
[axon-system-plugin] [axon-system] Minor fixes

### DIFF
--- a/axon-system-plugin/src/main/java/ai/stapi/axonsystemplugin/commandpersisting/CommitCommandFixturesLineRunner.java
+++ b/axon-system-plugin/src/main/java/ai/stapi/axonsystemplugin/commandpersisting/CommitCommandFixturesLineRunner.java
@@ -1,6 +1,7 @@
 package ai.stapi.axonsystemplugin.commandpersisting;
 
 import ai.stapi.axonsystem.commandpersisting.CommitCommandFixtures;
+import java.util.Arrays;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -21,9 +22,15 @@ public class CommitCommandFixturesLineRunner implements CommandLineRunner {
 
   @Override
   public void run(String... args) throws Exception {
-    var outputDirectoryPath = System.getProperty("user.dir")
-        + "/src/main/java/com/geniolab/application/Core/Fixtures/__generated__";
-    this.commandGateway.sendAndWait(new CommitCommandFixtures(outputDirectoryPath));
+    if (args.length == 0) {
+      throw new RuntimeException("Please specify path where to commit persisted commands as command line argument.");
+    }
+    var path = Arrays.stream(args)
+        .filter(arg -> arg.startsWith("_outputPath:"))
+        .map(arg -> arg.replace("_outputPath:", ""))
+        .findFirst();
+    
+    this.commandGateway.sendAndWait(new CommitCommandFixtures(path.orElse(args[0])));
     var exitCode = SpringApplication.exit(this.applicationContext, () -> 0);
     System.exit(exitCode);
   }

--- a/axon-system-plugin/src/main/java/ai/stapi/axonsystemplugin/structuredefinition/configure/ConfigureStructureDefinition.java
+++ b/axon-system-plugin/src/main/java/ai/stapi/axonsystemplugin/structuredefinition/configure/ConfigureStructureDefinition.java
@@ -18,7 +18,7 @@ public class ConfigureStructureDefinition extends AbstractCommand<UniqueIdentifi
     this.structureDefinitionData = structureDefinitionData;
   }
 
-  public StructureDefinitionData getStructureDefinitionDTO() {
+  public StructureDefinitionData getStructureDefinitionData() {
     return structureDefinitionData;
   }
 }

--- a/axon-system-plugin/src/main/java/ai/stapi/axonsystemplugin/structuredefinition/configure/ConfigureStructureDefinitionHandler.java
+++ b/axon-system-plugin/src/main/java/ai/stapi/axonsystemplugin/structuredefinition/configure/ConfigureStructureDefinitionHandler.java
@@ -28,7 +28,7 @@ public class ConfigureStructureDefinitionHandler {
 
   @CommandHandler
   public void handle(ConfigureStructureDefinition command) {
-    var structureDefinitionDTO = command.getStructureDefinitionDTO();
+    var structureDefinitionDTO = command.getStructureDefinitionData();
     this.structureSchemaProvider.add(structureDefinitionDTO);
     this.eventGateway.publish(
         new StructureDefinitionConfigured(

--- a/axon-system/src/main/java/ai/stapi/axonsystem/dynamic/command/DynamicCommandDispatchInterceptor.java
+++ b/axon-system/src/main/java/ai/stapi/axonsystem/dynamic/command/DynamicCommandDispatchInterceptor.java
@@ -19,7 +19,7 @@ public class DynamicCommandDispatchInterceptor  implements MessageDispatchInterc
     return (integer, commandMessage) -> {
       if (commandMessage.getPayload() instanceof DynamicCommand dynamicCommand) {
         return new GenericCommandMessage<>(
-            new GenericMessage<>(dynamicCommand),
+            new GenericMessage<>(dynamicCommand, commandMessage.getMetaData()),
             dynamicCommand.getSerializationType()
         );
       }


### PR DESCRIPTION
[axon-system] DynamicCommandDispatchInterceptor - now retains metadata
[axon-system-plugin] CommitCommandFixturesLineRunner now accepts output path as command line argument, Fix ConfigureStructureDefinition